### PR TITLE
Select a saved project and reload old project in view

### DIFF
--- a/client/src/components/Projects/projectView.js
+++ b/client/src/components/Projects/projectView.js
@@ -3,10 +3,11 @@ import { connect } from "react-redux"
 import {Card, CardActions, CardHeader, CardMedia, CardTitle, CardText} from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import _ from 'lodash';
-
-import { updateTree } from '../../actions/codeActions';
-
 import Tree from '../../dataStructure/tree.js'
+import dragItems from '../../dragItems';
+import { updateTree } from '../../actions/codeActions';
+import { BrowserRouter as Router, Route, Link } from 'react-router-dom';
+
 
 
 @connect((store) => {
@@ -50,33 +51,36 @@ class ProjectView extends React.Component {
     console.log('I AM ROOOOOOOOOOOOOOOOOT: ', tempTree['_root']);
 
     var rootComponent = tempTree['_root'].component;
+    var rootComponentName = tempTree['_root'].componentName;
     var rowObject =  {
-        linkedList: {},
-        head: null,
-        tail: null,
-        renderLinkedList: [],
+      linkedList: {},
+      head: null,
+      tail: null,
+      renderLinkedList: [],
     };
 
-    // tree['_root'].ID =  " "
-    // tree['_root'].children[0].parentID
-
     var oldRootChildren = tempTree['_root'].children;
-    console.log('CHILDREN FOR ADDING!!! ', oldRootChildren);
 
-    // function Node(component, rowObject, isRow)
-    var newRootTree = new Tree(rootComponent, rowObject, false);
+    // function Node(component, rowObject, isRow, compName)
+    var newRootTree = new Tree(rootComponent, rowObject, false, rootComponentName );
     newRootTree['_root'].children = oldRootChildren;
-    newRootTree['_root'].ID = tempTree['_root'].children[0].parentID;
+
+    if (newRootTree['_root'].children.length > 0) {
+      newRootTree['_root'].ID = newRootTree['_root'].children[0].parentID;
+    }
+
+    newRootTree.traverseDF((node) => {
+      node.component = dragItems[node.componentName];
+    });
+
     console.log('NEW ROOT TREE: ', newRootTree);
 
-    console.log('returning tree****************')
     return newRootTree;
   }
 
   handleClick(treeString) {
     var treeObject = JSON.parse(treeString);
     var selectedTree = this.addPrototypesToTree(treeObject);
-    console.log('dispatching tree********************')
     this.props.dispatch(updateTree(selectedTree));
   }
 
@@ -96,7 +100,7 @@ class ProjectView extends React.Component {
                     {project.description}
                   </CardText>
                   <CardActions>
-                    <FlatButton label="Load Project" onClick={this.handleClick.bind(this, project.object)}/>
+                    <Link to="/"><FlatButton label="Load Project" onClick={this.handleClick.bind(this, project.object)}/></Link>
                   </CardActions>
                 </Card>
               </div>

--- a/client/src/components/Projects/projectView.js
+++ b/client/src/components/Projects/projectView.js
@@ -21,31 +21,67 @@ class ProjectView extends React.Component {
 
   constructor(props) {
     super(props);
-    console.log('THIS.PROPS.PROJECTDATA*************************');
-    console.log(this.props.projectData);
-    console.log(Array.isArray((this.props.projectData)));
-    console.log('PROJECTS: ', this.props.projects);
+    this.state = { projectData: [] }
     this.handleClick = this.handleClick.bind(this);
   }
 
-  handleClick(objectTree) {
 
-    // var newTree = new Tree(
-    //   objectTree
-    // )
-    var someCode = JSON.parse(objectTree);
 
-    Object.prototype.someCode = Tree.traverseRendering;
+  componentWillReceiveProps(nextProps) {
+    console.log('@@@ inside componentWillReceiveProps')
+    console.log('this.props.projectData: ', this.props.projectData);
+    console.log('nextprops projectdata: ', nextProps.projectData)
+    console.log('STATE!!', this.state.projectData);
 
-    console.log('OBJECT TREE: ', someCode);
-    console.log('TYPE OF TREE', typeof someCode);
-    console.log('AFTER PARSING: ', someCode);
+    if(nextProps.projectData !== this.props.projectData) {
+      console.log('@@@ inside IF nextProps.projectData !== this.props.projectData');
+      this.setState({projectData: nextProps.projectData }, ()=> {
+        console.log('STATE!!', this.state.projectData);
+        var PD = this.state.projectData;
+        PD.forEach((proj,idx) => {
+          console.log(`project #${idx+1}: `, proj);
+          console.log('project code: ', proj.object);
+        });
+      });
+    }
+  }
 
-    this.props.dispatch(updateTree(someCode));
+  addPrototypesToTree(tempTree) {
+    console.log('I AM ROOOOOOOOOOOOOOOOOT: ', tempTree['_root']);
+
+    var rootComponent = tempTree['_root'].component;
+    var rowObject =  {
+        linkedList: {},
+        head: null,
+        tail: null,
+        renderLinkedList: [],
+    };
+
+    // tree['_root'].ID =  " "
+    // tree['_root'].children[0].parentID
+
+    var oldRootChildren = tempTree['_root'].children;
+    console.log('CHILDREN FOR ADDING!!! ', oldRootChildren);
+
+    // function Node(component, rowObject, isRow)
+    var newRootTree = new Tree(rootComponent, rowObject, false);
+    newRootTree['_root'].children = oldRootChildren;
+    newRootTree['_root'].ID = tempTree['_root'].children[0].parentID;
+    console.log('NEW ROOT TREE: ', newRootTree);
+
+    console.log('returning tree****************')
+    return newRootTree;
+  }
+
+  handleClick(treeString) {
+    var treeObject = JSON.parse(treeString);
+    var selectedTree = this.addPrototypesToTree(treeObject);
+    console.log('dispatching tree********************')
+    this.props.dispatch(updateTree(selectedTree));
   }
 
   render() {
-    var projects = this.props.projectData;
+    var projects = this.state.projectData;
 
     return (
       <div className="center-content">


### PR DESCRIPTION
- Able to select a previously created project
- Creates a new tree from the object retrieved from postgres
- New tree has prototype methods and previous children
- Maps over all nodes and adds component element lost when saved to database
- Updates tree with old tree
- Routes back to main view
- Still need to implement ability to save/reload projects with columns (linked list problem)
- Added componentWillReceiveProps method to keep all projects in sync with DB query
- Changed to using state instead of props to map projects